### PR TITLE
fix shell injection upon calling pdftk

### DIFF
--- a/pdfoutliner/__main__.py
+++ b/pdfoutliner/__main__.py
@@ -2,6 +2,7 @@
 import os
 import re
 import argparse
+from subprocess import run
 
 def main():
     parser = argparse.ArgumentParser()
@@ -148,8 +149,8 @@ def main():
         else:
             update_info = "update_info"
 
-        os.system("pdftk {} {} {} output {}".format(args.inpdf, 
-            update_info, marks_path, pdf_out_path))
+        run(["pdftk", args.inpdf, update_info, marks_path, "output", pdf_out_path],
+            check=True)
         # Delete intermediary bookmark file
         os.remove(marks_path)
 


### PR DESCRIPTION
I came across an error like this:

```
$ pdfoutliner toc.txt --inpdf "(John Smith) IRS.pdf" --outpdf '(John Smith) IRS new.pdf'
sh: 1: Syntax error: "(" unexpected
```

Again the argument is easily intepreted as a shell command, which easily causes trouble:

```
$ pdfoutliner toc.txt --inpdf "IRS.pdf" --outpdf '; exit'
Error: Failed to open output file:
   /home/user/
   No output created.
   No output created.
```

(I should be able to name a file '; exit' if I want to)